### PR TITLE
bumped up to python3.12 & tf 2.16 (some tf code changed were needed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.12
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=68.0.0", "wheel>=0.41.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,19 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 reqs = [
-    "tensorflow-macos==2.9.0;platform_system=='Darwin'",
-    "tensorflow==2.9.0;platform_system!='Darwin'",
-    "numpy==1.22.3",
-    "matplotlib==3.5.2",
-    "pandas==1.4.3",
-    "scikit-learn==1.0.2",
-    "xlrd==1.2.0",
-    "yattag==1.14",
-    "pillow==9.2.0",
-    "pytest==7.1.2",
-    "protobuf==3.20.0",
+    "tensorflow-macos==2.16.2;platform_system=='Darwin'",
+    "tensorflow==2.16.2;platform_system!='Darwin'",
+    "numpy==1.26.4",
+    "matplotlib==3.8.3",
+    "pandas==2.2.1",
+    "scikit-learn==1.7.1",
+    "xlrd==2.0.1",
+    "yattag==1.15.1",
+    "pillow==10.2.0",
+    "pytest==8.0.2",
+    "protobuf==4.25.3",
     "statsmodels==0.14.2",
+    "scipy==1.12.0",  # Added specific scipy version compatible with statsmodels
     "quadprog==0.1.12",
     "cvxopt==1.3.2",
 ]
@@ -38,6 +39,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=["swotann"],
-    python_requires=">=3.10",
+    python_requires=">=3.12",
     install_requires=reqs,
 )

--- a/swotann/QuantReg_Functions.py
+++ b/swotann/QuantReg_Functions.py
@@ -1,5 +1,8 @@
 import keras
-import keras.backend as K
+
+import tensorflow as tf
+from tensorflow import keras
+
 import numpy as np
 import pandas as pd
 import tensorflow as tf
@@ -13,37 +16,37 @@ from matplotlib import pyplot as plt
 def pinball_loss_keras(q):
     def loss(y_true,y_pred):
         e=(y_true-y_pred)
-        return K.mean(K.maximum(q*e,(q-1)*e))
+        return tf.reduce_mean(tf.maximum(q*e,(q-1)*e))
     return loss
 
 def smoothed_pinball_keras(q,eps):
     def loss(y_true,y_pred):
         e=y_true-y_pred
-        esq=K.square(e)/(2*eps)
-        elin=tf.subtract(K.abs(e),0.5*eps)
-        eesq=esq*K.cast(K.less(K.abs(e),eps),'float32')
-        eelin=elin*K.cast(K.greater_equal(K.abs(e),eps),'float32')
+        esq=tf.square(e)/(2*eps)
+        elin=tf.subtract(tf.abs(e),0.5*eps)
+        eesq=esq*tf.cast(tf.less(tf.abs(e),eps),'float32')
+        eelin=elin*tf.cast(tf.greater_equal(tf.abs(e),eps),'float32')
         ee=eelin+eesq
-        return K.mean(tf.where(e>0,q*ee,(1-q)*ee))
+        return tf.reduce_mean(tf.where(e>0,q*ee,(1-q)*ee))
     return loss
 
 def simultaneous_loss_keras(quantiles,eps):
     def loss(y_true,y_pred):#rewrite loss hear as the mean of the means
         e=(y_true-y_pred)
-        esq = K.square(e) / (2 * eps)
-        elin = tf.subtract(K.abs(e), 0.5 * eps)
-        eesq = esq * K.cast(K.less(K.abs(e), eps), 'float32')
-        eelin = elin * K.cast(K.greater_equal(K.abs(e), eps), 'float32')
+        esq = tf.square(e) / (2 * eps)
+        elin = tf.subtract(tf.abs(e), 0.5 * eps)
+        eesq = esq * tf.cast(tf.less(tf.abs(e), eps), 'float32')
+        eelin = elin * tf.cast(tf.greater_equal(tf.abs(e), eps), 'float32')
         ee = eelin + eesq
         e_upper=ee*quantiles
         e_lower=ee*(1-quantiles)
         q_e=tf.where(e>0,e_upper,e_lower)
 
-        q_err=K.mean(q_e,axis=0)#Should remove the N dimension, reduce to a mean per quantile
-        sum_q_err=K.mean(q_err)
+        q_err=tf.reduce_mean(q_e,axis=0)#Should remove the N dimension, reduce to a mean per quantile
+        sum_q_err=tf.reduce_mean(q_err)
         return sum_q_err
 
-        #return K.mean(K.mean(K.maximum(quantiles*e,(quantiles-1)*e,axis=0),axis=0)) #
+        #return tf.reduce_mean(tf.reduce_mean(tf.maximum(quantiles*e,(quantiles-1)*e,axis=0),axis=0)) #
 
     return loss
 

--- a/swotann/swot_ml.py
+++ b/swotann/swot_ml.py
@@ -287,7 +287,8 @@ class SWOT_ML(object):
         x_norm = self.predictors_scaler.transform(self.predictors)
         t_norm = self.targets_scaler.transform(self.targets)
 
-        self.model.fit(x_norm,t_norm.flatten())
+        # self.model.fit(x_norm,t_norm.flatten())
+        self.model.fit(x_norm,t_norm)
         self.calibration_predictions = self.model.predict(x_norm)
         for key in self.calibration_predictions.keys():
             self.calibration_predictions[key] = self.targets_scaler.inverse_transform(self.calibration_predictions[key].reshape(-1, 1)).flatten()


### PR DESCRIPTION
Bumping up to newer python/TF versions. Should help run the model marginally faster on latest MacOS  CPUs/GPUs.

Summary of changes:

- bumped up the library versions
- replaced direct Keras calls with indirect ones through TF.
- replaced K.mean() with tf.reduce_mean() which is the suggested way.

Validation steps taken:

- NN training results stay the same
- Unit tests pass